### PR TITLE
Safe child reaping on accept() client without sig handler.

### DIFF
--- a/hpws.c
+++ b/hpws.c
@@ -416,7 +416,11 @@ int main(int argc, char **argv)
             // send self pid down the control line as a four byte integer
             uint32_t to_send = (uint32_t)getpid();
             if (send(control_fd[0], (unsigned char*)(&to_send), sizeof(uint32_t), 0) < sizeof(uint32_t))
+            {
+                // TODO: If for some reason pid sending failed, then we'll end up as a zombie since the consumer process
+                // cannot reap us without knowing our pid. Currently there's no way to avoid this.
                 ABEND(80, "could not send pid down control line");
+            }
 
             break;
         }

--- a/test.cpp
+++ b/test.cpp
@@ -1,5 +1,6 @@
 #include <sys/wait.h>
 #include <sys/resource.h>
+#include <sys/prctl.h>
 #include <variant>
 #include <vector>
 #include "hpws.hpp"
@@ -18,6 +19,10 @@ int example_server();
 int example_client();
 
 int main(int argc, char** argv) {
+
+    // Become a sub-reaper so we can gracefully reap hpws child processes via hpws.hpp.
+    // (Otherwise they will get reaped by OS init process and we'll end up with race conditions with gracefull kills)
+    prctl(PR_SET_CHILD_SUBREAPER, 1);
 
     if (argc > 1 && argv[1][0] == 'c')
         return example_client();

--- a/test.cpp
+++ b/test.cpp
@@ -1,4 +1,3 @@
-#include <signal.h>
 #include <sys/wait.h>
 #include <sys/resource.h>
 #include <variant>
@@ -17,25 +16,8 @@
 
 int example_server();
 int example_client();
-void proc_exit(int x)
-{
-		int wstat;
-		pid_t pid;
-
-		while (1) {
-			pid = wait3 (&wstat, WNOHANG, (struct rusage *)NULL );
-			if (pid == 0)
-				return;
-			else if (pid == -1)
-				return;
-			else
-				fprintf (stderr, "[TEST.CPP] Child exit - Return code: %d\n", wstat);
-            sleep(1);
-		}
-}
 
 int main(int argc, char** argv) {
-    signal (SIGCHLD, proc_exit);
 
     if (argc > 1 && argv[1][0] == 'c')
         return example_client();


### PR DESCRIPTION
We shouldn't depend on SIGCHLD handler to reap child processes because it can cause race conditions on intentional kills by hpws::client and hpws::server (eg. if the child pid is reaped by sig handler and then hpws::client killing the old pid which now may have been assigned to a different process)
The new approach is for the consumer process (eg. hpcore) to nominate itself as a sub-reaper and for the child to double-fork and detach from hpws server parent process. This allows the child pid to be properly killed and wait()ed from hpcore/hpws::client.