### PR TITLE
Increasing timeouts to accomodate possible delays in HP VM cluster testing.

### DIFF
--- a/hpws.c
+++ b/hpws.c
@@ -34,7 +34,7 @@
 #define DEBUG 0
 #define VERBOSE_DEBUG 0
 #define SSL_BUFFER_LENGTH 4096
-#define POLL_TIMEOUT 50 /* ms */
+#define POLL_TIMEOUT 500 /* ms */ // This timeout has to account the possible delays in communication via internet.
 #define CLIENT_SHUTDOWN_CYCLES 3
 #define CLIENT_SHUTDOWN_FINAL_TIMEOUT 5000 /* microseconds */
 #define _GNU_SOURCE

--- a/hpws.hpp
+++ b/hpws.hpp
@@ -47,7 +47,7 @@ namespace hpws
 // used when waiting for messages that should already be on the pipe
 #define HPWS_SMALL_TIMEOUT 10
 // used when waiting for server process to spawn
-#define HPWS_LONG_TIMEOUT 50
+#define HPWS_LONG_TIMEOUT 1500 // This timeout has to account the possible delays in communication via internet.
 
     typedef union
     {


### PR DESCRIPTION
- HPWS_LONG_TIMEOUT is increased from 50ms to 1500ms.
- POLL_TIMEOUT is increased from 50ms to 500ms.